### PR TITLE
Added ability to pull dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby '2.5.3'
 
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'dotenv'
+gem 'graphql-client'
 gem 'jbuilder', '~> 2.7'
 gem 'pg'
 gem 'puma', '~> 4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,10 @@ GEM
     ffi (1.12.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    graphql (1.10.0)
+    graphql-client (0.16.0)
+      activesupport (>= 3.0)
+      graphql (~> 1.8)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jbuilder (2.9.1)
@@ -201,6 +205,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   dotenv
   dotenv-rails
+  graphql-client
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   pg

--- a/app/models/package_manager.rb
+++ b/app/models/package_manager.rb
@@ -1,4 +1,14 @@
 class PackageManager < ApplicationRecord
+  MANAGERS = {
+    'RUBYGEMS' => 'ruby',
+    'NPM' => 'javascript',
+  }
   belongs_to :language
   has_many :dependencies
+  before_validation :set_language, on: :create
+
+  private
+  def set_language
+    self.language = Language.find_or_create_by(name: MANAGERS[self.name])
+  end
 end

--- a/app/services/dependency_fetcher.rb
+++ b/app/services/dependency_fetcher.rb
@@ -1,0 +1,71 @@
+require "graphql/client"
+require "graphql/client/http"
+
+class DependencyFetcher
+  class << self
+
+    def http_client
+      @http ||= GraphQL::Client::HTTP.new("https://api.github.com/graphql") do
+        def headers(context)
+          {
+            "Accept": "application/vnd.github.hawkgirl-preview+json",
+            "Authorization": "token #{ENV['GITHUB_TOKEN']}"
+          }
+        end
+      end  
+    end
+
+    def schema
+      @schema ||= GraphQL::Client.load_schema(http_client)
+    end
+
+    def client
+      @client ||= GraphQL::Client.new(schema: schema, execute: http_client)
+    end
+
+    def get_dependencies(project)
+      manifests = client.query(
+        DependencyFetcher::QUERY_SCHEMA,
+        variables: {
+          repository_owner: project.organization.name,
+          repository_name: project.name,
+        }
+      ).data.repository.dependency_graph_manifests.nodes
+      manifests.map do |manifest|
+        manifest.dependencies.nodes.each do |dependency_response|
+          package_manager = PackageManager.find_or_create_by!(
+            name: dependency_response.package_manager,
+          )
+
+          dependency = Dependency.find_or_create_by!(
+            name: dependency_response.package_name,
+            package_manager: package_manager,
+          )
+
+          project.dependency_instances.find_or_create_by!(
+            dependency: dependency,
+          ).update!(version: dependency_response.requirements)
+        end
+      end
+    end
+  end
+
+  QUERY_SCHEMA = client.parse <<-'GRAPHQL'
+    query($repository_owner: String!, $repository_name: String!) {
+      repository(owner: $repository_owner, name: $repository_name) {
+        dependencyGraphManifests {
+          nodes {
+            filename
+            dependencies {
+              nodes {
+                packageName
+                packageManager
+                requirements
+              }
+            }
+          }
+        }
+      }
+    }
+  GRAPHQL
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module Icebreaker
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.autoload_paths << "#{Rails.root}/app/services/*"
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
This adds the functionality to pull depdendency information from the Github API for a project.
It should be noted that not all packagemanagers have language translations. It should also be
noted that this does not take into account lock files, so dependency versions may not be 100%
accurate until we rectify that.