### PR TITLE
Sprout initial landing page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,17 @@
+class HomeController < ApplicationController
+  def show
+
+  end
+
+  helper_method def dependencies
+    @dependencies ||= Dependency.all
+      .with_projects
+      .ordered_by_name
+      .map { |dependency| to_presenter(dependency) }
+      .sort_by(&:weight)
+  end
+
+  private def to_presenter(dependency)
+    DependencyPresenter.new(dependency)
+  end
+end

--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -6,6 +6,9 @@ class Dependency < ApplicationRecord
 
   before_validation :update_with_details, on: :create
 
+  scope :with_projects, -> { includes(:projects) }
+  scope :ordered_by_name, -> { order("dependencies.name ASC") }
+
   def update_with_details
     details = DependencyDetailsFetcher.new(self).fetch
     license_name = details[:license] || "Unknown"
@@ -13,5 +16,4 @@ class Dependency < ApplicationRecord
     self.source_repo_url = details[:url]
     self.license = license
   end
-
 end

--- a/app/views/dependencies/_as_metaphorical_stone.html.erb
+++ b/app/views/dependencies/_as_metaphorical_stone.html.erb
@@ -1,0 +1,8 @@
+<div class="dependency" style="font-size: 1.<%= dependency.weight %>em;">
+  <h3><%= link_to dependency.name, dependency.url, target: "_new" %></h3>
+  <h4><%= dependency.language %></h4>
+  <h4><%= dependency.license %></h4>
+  <% dependency.projects.each do |project| %>
+    <%= link_to project.github_identifier, project.repo_url, target: "_new" %><br />
+  <% end %>
+</div>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,0 +1,86 @@
+<section id="1-ice-violates-human-rights">
+      <h2>
+        <a href="#1-ice-violates-human-rights">ICE Violates Human Rights. #NoTechForICE</a>
+      </h2>
+
+      <p>
+        On any given day, <a href="https://commons.wikimedia.org/wiki/File:ADP_Detained_Immigrants_1994-2018.png">40,000 people are detained</a> by ICE
+        in <a href="https://www.motherjones.com/politics/2018/10/ice-adelanto-detention-facility-inspector-report/">unsafe and unsanitary conditions</a>
+        with <a href="https://www.aclu.org/report/code-red-fatal-consequences-dangerously-substandard-medical-care-immigration-detention">sub-standard
+        medical care</a> with <a href="https://www.americanimmigrationcouncil.org/research/access-counsel-immigration-court">sporadic, if any, access to legal counsel.</a>
+      </p>
+
+      <p>
+        These conditions have led directly to <a href="https://www.ice.gov/doclib/foia/reports/detaineedeaths-2003-2017.pdf">nearly two hundred
+        detainee deaths at the hands of ICE</a>.
+      </p>
+
+      <p>
+        And if the human costs are not enough to persuade you, consider the financial ones. In 2018,
+        <a href="https://immigrationforum.org/article/math-immigration-detention-2018-update-costs-continue-mulitply/">tax payers spent $3.076 billion
+          dollars on DHS Custody Operations</a>. A budget four times greater than the Department of Education's
+        <a href="https://www2.ed.gov/about/overview/budget/budget18/budget-factsheet.pdf">English Language Acquisition programs</a>.
+      </p>
+
+      <p>In addition to the cruelty of ICE and the financial costs to tax-payers, ICE is the public face
+        <a href="https://www.aclu.org/report/emergence-global-infrastructure-mass-registration-and-surveillance-report">
+          of the United States&rsquo; ever-expanding domestic surveillance apparatus.</a> How? Through lucrative contracts with
+          privately held technology companies like <a href="https://www.motherjones.com/politics/2019/08/ice-palantir-contract-amount-revealed/">Palantir</a>,
+        <a href="https://www.theverge.com/2018/6/21/17488328/microsoft-ice-employees-signatures-protest">Microsoft</a>, and even darling
+        <a href="https://www.washingtonpost.com/technology/2019/10/09/employees-ask-github-cancel-ice-contract-we-cannot-offset-human-lives-with-money/">GitHub</a>.
+      </p>
+    </section>
+    <section id="2-using-our-labor">
+      <h2><a href="#2-using-ourlabor">Using Our Labor</a></h2>
+      <p>
+        At present, <a href="https://github.com/palantir">Palantir has nearly 280 Open Source repositories hosted on GitHub</a>; which rely on
+        <a href="/projects/">thousands of dependencies</a>. Every dependency in use ICE and Palantir is used to directly violate human rights.
+        Each dependency is a stone in the wall between reality and the dream of Open Source as a champion of freedom, liberty and equality.
+      </p>
+
+      <p>
+        But don't despair. There is hope. You can help.
+      </p>
+    </section>
+
+    <section id="3-tear-down-the-wall">
+      <h2>
+        <a href="#3-tear-down-the-wall">Tear Down The Wall!</a>
+      </h2>
+      <p>
+        Below is the wall we have built for ICE. Every dependency used in Palantir's Open Source projects is listed here,
+        with small, actionable next steps for how to remove Palantir's ability to use that dependency to further violate
+        human rights.
+      </p>
+
+      <section id="3-a-searchable-dependencies">
+        <fieldset id="3-a-1-filters">
+          <div>
+            <label for="filter-programming-languages">
+              Filter by Programming Language
+            </label>
+            <select id="filter-programming-languages" name="filter[programming_languages]" multiple="true">
+              <option value="ruby">Ruby</option>
+              <option value="javascript">JavaScript / Node / TypeScript</option>
+              <option value="go">GoLang</option>
+              <option value="java">Java / Scala / Clojure</option>
+            </select>
+          </div>
+
+          <div>
+            <label for="filter-dependency=name">Filter by Dependency Name</label>
+            <input type="search" id="filter-dependency-name" name="filter[dependency_name]" placeholder="Dependencies whose names contain..." />
+          </div>
+          <div>
+            <button>
+              Filter Dependencies
+            </button>
+          </div>
+        </fieldset>
+        <section id="3-a-2-dependencies">
+          <%- dependencies.each do |dependency| %>
+            <%= render "dependencies/as_metaphorical_stone", dependency: dependency %>
+          <%- end %>
+        </section>
+      </section>
+    </section>

--- a/app/views/projects/_dependency.html.erb
+++ b/app/views/projects/_dependency.html.erb
@@ -1,0 +1,8 @@
+
+  <div class="dependency" style="font-size: 1.<%= dependency.weight %>em;">
+    <h3><%= link_to dependency.name, dependency.url, target: "_new" %></h3>
+    <h4><%= dependency.language %></h4>
+    <% dependency.projects.each do |project| %>
+      <%= link_to project.github_identifier, project.repo_url, target: "_new" %><br />
+    <% end %>
+  </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 require "resque_web"
 
 Rails.application.routes.draw do
-
-  root "projects#index"
-
   mount ResqueWeb::Engine => "/resque_web"
 
+  resources :projects, only: [:index, :show]
+
+  root "home#show"
 end


### PR DESCRIPTION
The projects index seems like the right place for a list of different
Palantir/Microsoft/Github projects so that if a contributor has an issue
with a particular project they can find it.

The home page is where we want the prominent activation messages and
calls-to-action.

![Screenshot_2020-01-26 Icebreaker](https://user-images.githubusercontent.com/50284/73147330-c93b3380-406b-11ea-88fe-9db18d47ecae.png)
